### PR TITLE
Add required PHP version into plugin preview

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -5,6 +5,7 @@ Tags: responsive, menu, responsive menu, mobile menu, wordpress responsive menu,
 Requires at least: 3.6
 Tested up to: 4.9
 Stable tag: 3.1.9
+Requires PHP: 5.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
Related info: https://make.wordpress.org/plugins/2017/08/29/minimum-php-version-requirement/

It'll be more clear for end-users. Anyway, we should track https://core.trac.wordpress.org/ticket/40934  for future improvements.