### PR TITLE
Load the menu template in wp_footer hook

### DIFF
--- a/v4.0.0/inc/classes/class-plugin.php
+++ b/v4.0.0/inc/classes/class-plugin.php
@@ -122,6 +122,12 @@ class Plugin {
 	 */
 	public function has_support( $hook ) {
 
+		// Check wp footer option is enabled.
+		$option_manager  = Option_Manager::get_instance();
+		if ( 'wp_body_open' == $hook && 'on' == $option_manager->get_global_option( 'rmp_wp_footer_hook' ) ) {
+			return false;
+		}
+
 		// Check wp core support wp_body_open hook or not.
 		if( ! has_action( $hook ) ) {
 			return false;

--- a/v4.0.0/inc/helpers/default-options.php
+++ b/v4.0.0/inc/helpers/default-options.php
@@ -27,6 +27,7 @@ function rmp_global_default_setting_options() {
         'rmp_remove_glyphicon' => 'off',
         'rmp_remove_dashicons' => 'off',
         'rmp_remove_material_icons' => 'off',
+        'rmp_wp_footer_hook' => 'off'
     ];
 }
 

--- a/v4.0.0/templates/rmp-settings.php
+++ b/v4.0.0/templates/rmp-settings.php
@@ -95,6 +95,20 @@ if ( ! empty( $global_settings['menu_adjust_for_wp_admin_bar'] ) )  {
                         </tr>
 
                         <tr>
+                            <th scope="row"> <?php esc_html_e( 'Use wp_footer hook', 'responsive-menu-pro'); ?></th>
+                            <td>
+                                <fieldset>
+                                    <p>
+                                        <input type="checkbox" name="rmp_wp_footer_hook" value="on" id="rmp-wp-footer-hook" <?php echo is_rmp_option_checked( 'on', $global_settings, 'rmp_wp_footer_hook' );?> > 
+                                        <label for="rmp-wp-footer-hook" class="description">
+                                            <?php esc_html_e( 'Enable this option if your theme does not support wp_body_open hook.', 'responsive-menu-pro'); ?>
+                                        </label>
+                                    </p>
+                                </fieldset>
+                            </td>
+                        </tr>
+
+                        <tr>
                             <th scope="row"> <?php esc_html_e( 'Use external files', 'responsive-menu-pro'); ?></th>
                             <td>
                                 <fieldset>


### PR DESCRIPTION
Load the menu template in wp_footer hook if the theme does not support wp_body_open action.